### PR TITLE
Create auto-generate-connector.yml

### DIFF
--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -1,0 +1,487 @@
+name: Auto-Generate and Analyze Connector
+
+on:
+  repository_dispatch:
+    types: [openapi-update, analyze-connector-changes]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    name: Generate connector using reusable workflow
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'orgBBalLib' }}
+    uses: orgBBalLib/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+    with:
+      openapi-url: ${{ github.event.client_payload.openapi_url }}
+      distribution-zip: ""
+      license-file: "license.txt"
+      quiet-mode: false
+      regenerate-existing: true
+
+  analyze:
+    name: Analyze connector version changes
+    needs: [generate]
+    if: ${{ always() && (needs.generate.result == 'success' || needs.generate.result == 'skipped') }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Set up Ballerina
+        uses: ballerina-platform/setup-ballerina@v1.1.0
+        with:
+          version: latest
+
+      - name: Find auto-generate-connector branch
+        id: find_branch
+        run: |
+          git fetch origin
+          BRANCH_NAME=$(git branch -r | grep -E 'origin/auto-generate-connector' | \
+            sed 's/origin\///' | \
+            sed 's/^[[:space:]]*//' | \
+            sort -r | \
+            head -1)
+
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "Error: No auto-generate-connector branch found"
+            exit 1
+          fi
+
+          echo "Found latest branch: $BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Generate git diff for client.bal and types.bal
+        id: diff
+        run: |
+          BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
+          echo "Generating diff between origin/main and origin/$BRANCH_NAME..."
+
+          git diff origin/main..origin/$BRANCH_NAME -- ballerina/client.bal > client_diff.txt || true
+          git diff origin/main..origin/$BRANCH_NAME -- ballerina/types.bal > types_diff.txt || true
+          cat client_diff.txt types_diff.txt > git_diff.txt
+
+          if [ ! -s git_diff.txt ]; then
+            echo "No changes detected in client.bal or types.bal"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "Diff generated successfully"
+
+      - name: Clone ballerina-library scripts
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          git clone -b main https://github.com/orgBBalLib/ballerina-library.git temp-library
+
+      - name: Run analysis
+        if: steps.diff.outputs.has_changes == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          cp temp-library/connector_automator/modules/client_regenerator/analyze_version_change.bal ./
+          bal run analyze_version_change.bal -- "$(cat git_diff.txt)"
+          rm -f analyze_version_change.bal
+
+      - name: Display results
+        if: always()
+        run: |
+          if [ -f analysis_result.json ]; then
+            echo "Analysis Results:"
+            cat analysis_result.json | jq '.'
+          else
+            echo "No analysis result file found"
+          fi
+
+      - name: Update version in gradle.properties
+        if: steps.diff.outputs.has_changes == 'true'
+        id: update_version
+        run: |
+          BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
+          git stash || true
+          git checkout $BRANCH_NAME
+
+          CHANGE_TYPE=$(jq -r '.changeType' analysis_result.json)
+          CURRENT_VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
+          echo "Current version: $CURRENT_VERSION"
+
+          BASE_VERSION=$(echo $CURRENT_VERSION | sed 's/-SNAPSHOT//')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+          case $CHANGE_TYPE in
+            MAJOR)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            MINOR)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            PATCH)
+              PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "Unknown change type: $CHANGE_TYPE"
+              exit 1
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-SNAPSHOT"
+          echo "New version: $NEW_VERSION"
+
+          sed -i "s/^version=.*/version=$NEW_VERSION/" gradle.properties
+
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "change_type=$CHANGE_TYPE" >> $GITHUB_OUTPUT
+
+      - name: Update CHANGELOG.md
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          echo "Building PR description for changelog..."
+
+          # Initialize the PR description file
+          echo "### Summary" > pr_description.txt
+          jq -r '.summary' analysis_result.json >> pr_description.txt
+          echo "" >> pr_description.txt
+
+          # Add Breaking Changes section
+          echo "### Breaking Changes" >> pr_description.txt
+          BREAKING_COUNT=$(jq -r '.breakingChanges | length' analysis_result.json)
+          if [ "$BREAKING_COUNT" -gt 0 ]; then
+            jq -r '.breakingChanges[]' analysis_result.json | while IFS= read -r line; do
+              echo "- $line" >> pr_description.txt
+            done
+          else
+            echo "- None" >> pr_description.txt
+          fi
+          echo "" >> pr_description.txt
+
+          # Add New Features section
+          echo "### New Features" >> pr_description.txt
+          FEATURES_COUNT=$(jq -r '.newFeatures | length' analysis_result.json)
+          if [ "$FEATURES_COUNT" -gt 0 ]; then
+            jq -r '.newFeatures[]' analysis_result.json | while IFS= read -r line; do
+              echo "- $line" >> pr_description.txt
+            done
+          else
+            echo "- None" >> pr_description.txt
+          fi
+          echo "" >> pr_description.txt
+
+          # Add Improvements section
+          echo "### Improvements" >> pr_description.txt
+          FIXES_COUNT=$(jq -r '.bugFixes | length' analysis_result.json)
+          if [ "$FIXES_COUNT" -gt 0 ]; then
+            jq -r '.bugFixes[]' analysis_result.json | while IFS= read -r line; do
+              echo "- $line" >> pr_description.txt
+            done
+          else
+            echo "- None" >> pr_description.txt
+          fi
+
+          echo ""
+          echo "=== Generated PR Description ==="
+          cat pr_description.txt
+          echo "================================"
+          echo ""
+
+          # Sanitize pr_description.txt before passing to update_changelog.bal.
+          # The script does substring(0, 50) on every line it processes, which
+          # crashes on lines shorter than 50 characters. Pad every line to at
+          # least 50 characters with trailing spaces so the call is always safe.
+          python3 - <<'PYEOF'
+          with open("pr_description.txt", "r") as f:
+              lines = f.readlines()
+          with open("pr_description.txt", "w") as f:
+              for line in lines:
+                  stripped = line.rstrip("\n")
+                  if len(stripped) < 50:
+                      stripped = stripped.ljust(50)
+                  f.write(stripped + "\n")
+          PYEOF
+
+          # Run changelog updater via a temp Ballerina package
+          # (update_changelog.bal exports runUpdateChangelog, not main)
+          CHANGELOG_PKG=$(mktemp -d)
+          cp temp-library/connector_automator/modules/client_regenerator/update_changelog.bal "$CHANGELOG_PKG/"
+          cat > "$CHANGELOG_PKG/Ballerina.toml" << 'TOML'
+          [package]
+          org = "temp"
+          name = "changelog_runner"
+          version = "0.1.0"
+          TOML
+          cat > "$CHANGELOG_PKG/entry.bal" << 'BAL'
+          public function main(string prDescription) returns error? {
+              check runUpdateChangelog(prDescription);
+          }
+          BAL
+          bal run "$CHANGELOG_PKG" -- "$(cat pr_description.txt)"
+          rm -rf "$CHANGELOG_PKG"
+
+          # Verify CHANGELOG.md was created/updated
+          if [ -f "CHANGELOG.md" ]; then
+            echo "✅ CHANGELOG.md created/updated successfully"
+            echo "First 50 lines:"
+            head -50 CHANGELOG.md
+          else
+            echo "⚠️ WARNING: CHANGELOG.md was not created"
+            ls -la
+          fi
+
+      - name: Extract code owners
+        if: steps.diff.outputs.has_changes == 'true'
+        id: extract_owners
+        run: |
+          if [ -f ".github/CODEOWNERS" ]; then
+            OWNERS=$(grep -E '^\*' .github/CODEOWNERS | sed 's/^\*[[:space:]]*//' | tr -d '@' | tr ' ' ',' || echo "")
+            echo "code_owners=$OWNERS" >> $GITHUB_OUTPUT
+            echo "Found code owners: $OWNERS"
+          else
+            echo "code_owners=" >> $GITHUB_OUTPUT
+            echo "No CODEOWNERS file found"
+          fi
+
+      - name: Set up Java
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Run Gradle build to generate Ballerina files
+        id: gradle_build
+        if: steps.diff.outputs.has_changes == 'true'
+        continue-on-error: true
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.PAT_TOKEN }}
+        run: |
+          ./gradlew build -x test
+          echo "Generated Ballerina files:"
+          ls -la ballerina/Ballerina.toml ballerina/Dependencies.toml || true
+
+      - name: Commit version changes and generated files
+        if: steps.diff.outputs.has_changes == 'true'
+        run: |
+          BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
+          git config --local user.email "ballerina-bot@ballerina.io"
+          git config --local user.name "ballerina-bot"
+
+          echo "Files before git add:"
+          ls -la | grep -E '(CHANGELOG|gradle.properties|Ballerina.toml)'
+
+          # Add version file
+          git add gradle.properties
+
+          # Add CHANGELOG.md (case-insensitive, try all variants)
+          git add CHANGELOG.md 2>/dev/null || true
+          git add Changelog.md 2>/dev/null || true
+          git add changelog.md 2>/dev/null || true
+          git add ChangeLog.md 2>/dev/null || true
+
+          # Verify CHANGELOG.md is staged
+          if git diff --staged --name-only | grep -qi "changelog"; then
+            echo "✅ CHANGELOG.md is staged for commit"
+          else
+            echo "⚠️ WARNING: CHANGELOG.md is not staged!"
+            echo "Current directory contents:"
+            ls -la
+            echo "Git status:"
+            git status
+          fi
+
+          # Add generated Ballerina files if they exist
+          if [ -f ballerina/Ballerina.toml ]; then
+            git add ballerina/Ballerina.toml
+            echo "Added ballerina/Ballerina.toml"
+          fi
+          if [ -f ballerina/Dependencies.toml ]; then
+            git add ballerina/Dependencies.toml
+            echo "Added ballerina/Dependencies.toml"
+          fi
+
+          echo "Staged files:"
+          git diff --staged --name-only
+
+          # Clean up temporary files EXCEPT analysis_result.json (needed for PR creation)
+          rm -f update_changelog.bal pr_description.txt git_diff.txt client_diff.txt types_diff.txt
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            COMMIT_MSG="Update version to ${{ steps.update_version.outputs.new_version }} and update CHANGELOG"
+            if [ "${{ steps.gradle_build.outcome }}" == "failure" ]; then
+              COMMIT_MSG="$COMMIT_MSG [Gradle build failed - manual intervention required]"
+            else
+              COMMIT_MSG="$COMMIT_MSG and regenerate Ballerina files"
+            fi
+
+            echo "Committing with message: $COMMIT_MSG"
+            git commit -m "$COMMIT_MSG"
+
+            echo "Commit created. Files in commit:"
+            git show --name-only --oneline HEAD
+          fi
+
+          git push origin $BRANCH_NAME
+
+      - name: Create Pull Request
+        if: steps.diff.outputs.has_changes == 'true'
+        id: create_pr
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const analysis = JSON.parse(fs.readFileSync('analysis_result.json', 'utf8'));
+            const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
+            const branchName = '${{ steps.find_branch.outputs.branch_name }}';
+            const codeOwners = '${{ steps.extract_owners.outputs.code_owners }}';
+
+            function formatChange(change) {
+              const separators = [' - ', ': ', ' – '];
+              let separator = null;
+              let splitIndex = -1;
+
+              for (const sep of separators) {
+                const idx = change.indexOf(sep);
+                if (idx > -1) {
+                  separator = sep;
+                  splitIndex = idx;
+                  break;
+                }
+              }
+
+              if (splitIndex > -1) {
+                const description = change.substring(0, splitIndex);
+                const details = change.substring(splitIndex + separator.length);
+                const descHasCode = description.includes("'") || description.includes('"') || description.includes('`');
+
+                if (descHasCode) {
+                  const descFormatted = description.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
+                  return `${descFormatted} - ${details}`;
+                } else {
+                  return `${description} - \`${details}\``;
+                }
+              }
+
+              if (change.includes("'") || change.includes('"')) {
+                return change.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
+              }
+
+              return change;
+            }
+
+            let prBody = `## Version Change Analysis\n\n`;
+
+            if (gradleBuildFailed) {
+              prBody += `> ⚠️ WARNING: GRADLE BUILD FAILED - Manual intervention required\n\n`;
+            }
+
+            prBody += `**Recommended Version Bump:** \`${analysis.changeType}\`\n`;
+            prBody += `**New Version:** \`${{ steps.update_version.outputs.new_version }}\`\n`;
+            prBody += `**Confidence:** ${analysis.confidence}\n`;
+            prBody += `**Build Status:** ${gradleBuildFailed ? '❌ FAILED' : '✅ Success'}\n`;
+
+            if (codeOwners) {
+              prBody += `**Code Owners:** ${codeOwners.split(',').map(o => `@${o}`).join(', ')}\n`;
+            }
+
+            prBody += `\n### Summary\n${analysis.summary}\n\n`;
+
+            if (analysis.breakingChanges.length > 0) {
+              prBody += `### Breaking Changes\n`;
+              analysis.breakingChanges.forEach(change => {
+                prBody += `- ${formatChange(change)}\n`;
+              });
+              prBody += '\n';
+            }
+
+            if (analysis.newFeatures.length > 0) {
+              prBody += `### New Features\n`;
+              analysis.newFeatures.forEach(feature => {
+                prBody += `- ${formatChange(feature)}\n`;
+              });
+              prBody += '\n';
+            }
+
+            if (analysis.bugFixes.length > 0) {
+              prBody += `### Improvements\n`;
+              analysis.bugFixes.forEach(fix => {
+                prBody += `- ${formatChange(fix)}\n`;
+              });
+              prBody += '\n';
+            }
+
+            prBody += `---\n\n`;
+            if (gradleBuildFailed) {
+              prBody += `⚠️ BUILD FAILED - Please fix the Gradle build errors before merging.\n`;
+            }
+            prBody += `**CHANGELOG.md** has been automatically updated.\n\n`;
+            prBody += `Manual Review Required - Please review the changes and approve if appropriate.\n`;
+
+            const buildStatus = gradleBuildFailed ? '[BUILD FAILED] ' : '';
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `${buildStatus}[${analysis.changeType}] Auto-generated connector update - v${{ steps.update_version.outputs.new_version }}`,
+              head: branchName,
+              base: 'main',
+              body: prBody
+            });
+
+            console.log(`Created PR #${pr.data.number}`);
+            core.setOutput('pr_number', pr.data.number);
+            core.setOutput('pr_url', pr.data.html_url);
+            core.setOutput('pr_title', pr.data.title);
+
+            return pr.data.number;
+
+      - name: Add labels to PR
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
+            const labels = ['manual-review-required'];
+
+            if (gradleBuildFailed) {
+              labels.push('build-failed');
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.create_pr.outputs.result }},
+              labels: labels
+            });
+
+      - name: Upload analysis results
+        if: steps.diff.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: version-analysis
+          path: |
+            analysis_result.json
+            git_diff.txt
+            client_diff.txt
+            types_diff.txt
+
+      - name: Cleanup temporary files
+        if: always()
+        run: |
+          rm -f analysis_result.json update_changelog.bal pr_description.txt git_diff.txt client_diff.txt types_diff.txt
+          rm -rf temp-library

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   generate:
     name: Generate connector using reusable workflow
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'orgBBalLib' }}
+    uses: orgBBalLib/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -23,7 +23,7 @@ jobs:
   analyze:
     name: Analyze connector version changes
     needs: [generate]
-    if: ${{ always() && (needs.generate.result == 'success' || needs.generate.result == 'skipped') }}
+    if: ${{ always() && (needs.generate.result == 'success' || needs.generate.result == 'failure') }}
     runs-on: ubuntu-latest
 
     steps:
@@ -66,26 +66,41 @@ jobs:
         run: |
           BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
           echo "Generating diff between merge-base(origin/main, origin/$BRANCH_NAME) and origin/$BRANCH_NAME..."
+
+          # Check for ANY changes in the branch (gates PR creation)
+          TOTAL_CHANGED=$(git diff origin/main...origin/$BRANCH_NAME --name-only)
+          if [ -z "$TOTAL_CHANGED" ]; then
+            echo "No changes detected in branch"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_code_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "has_changes=true" >> $GITHUB_OUTPUT
+          echo "Changed files:"
+          echo "$TOTAL_CHANGED"
+
+          # Check client.bal/types.bal specifically (gates analysis, version bump, changelog)
           git diff origin/main...origin/$BRANCH_NAME -- ballerina/client.bal > client_diff.txt || true
           git diff origin/main...origin/$BRANCH_NAME -- ballerina/types.bal > types_diff.txt || true
           cat client_diff.txt types_diff.txt > git_diff.txt
 
           if [ ! -s git_diff.txt ]; then
-            echo "No changes detected in client.bal or types.bal"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            exit 0
+            echo "No changes in client.bal or types.bal - analysis will be skipped"
+            echo "has_code_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
+            echo "Code changes detected - analysis will run"
           fi
 
-          echo "has_changes=true" >> $GITHUB_OUTPUT
-          echo "Diff generated successfully"
-
       - name: Clone ballerina-library scripts
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_code_changes == 'true'
         run: |
-          git clone -b main https://github.com/ballerina-platform/ballerina-library.git temp-library
+          git clone -b main https://github.com/orgBBalLib/ballerina-library.git temp-library
 
       - name: Run analysis
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_code_changes == 'true'
+        id: run_analysis
+        continue-on-error: true
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
@@ -104,8 +119,9 @@ jobs:
           fi
 
       - name: Update version in gradle.properties
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_code_changes == 'true'
         id: update_version
+        continue-on-error: true
         run: |
           BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
           git stash || true
@@ -146,7 +162,8 @@ jobs:
           echo "change_type=$CHANGE_TYPE" >> $GITHUB_OUTPUT
 
       - name: Update CHANGELOG.md
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_code_changes == 'true'
+        continue-on-error: true
         run: |
           echo "Building PR description for changelog..."
 
@@ -253,7 +270,7 @@ jobs:
           fi
 
       - name: Set up Java
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_changes == 'true' && needs.generate.outputs.pipeline_succeeded == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -261,7 +278,7 @@ jobs:
 
       - name: Run Gradle build to generate Ballerina files
         id: gradle_build
-        if: steps.diff.outputs.has_changes == 'true'
+        if: steps.diff.outputs.has_changes == 'true' && needs.generate.outputs.pipeline_succeeded == 'true'
         continue-on-error: true
         env:
           packageUser: ${{ github.actor }}
@@ -273,6 +290,7 @@ jobs:
 
       - name: Commit version changes and generated files
         if: steps.diff.outputs.has_changes == 'true'
+        continue-on-error: true
         run: |
           BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
           git config --local user.email "ballerina-bot@ballerina.io"
@@ -337,17 +355,29 @@ jobs:
           git push origin $BRANCH_NAME
 
       - name: Create Pull Request
-        if: steps.diff.outputs.has_changes == 'true'
+        if: always() && steps.diff.outputs.has_changes == 'true'
         id: create_pr
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const fs = require('fs');
-            const analysis = JSON.parse(fs.readFileSync('analysis_result.json', 'utf8'));
             const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
+            const analysisFailed = '${{ steps.run_analysis.outcome }}' === 'failure';
+            const pipelineSucceeded = '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true';
             const branchName = '${{ steps.find_branch.outputs.branch_name }}';
             const codeOwners = '${{ steps.extract_owners.outputs.code_owners }}';
+
+            // analysis_result.json may not exist if analysis failed
+            let analysis = null;
+            try {
+              analysis = JSON.parse(fs.readFileSync('analysis_result.json', 'utf8'));
+            } catch (e) {
+              core.warning('analysis_result.json not found: ' + e.message);
+            }
+
+            const changeType = analysis ? analysis.changeType : 'UNKNOWN';
+            const newVersion = '${{ steps.update_version.outputs.new_version }}' || 'unknown';
 
             function formatChange(change) {
               const separators = [' - ', ': ', ' – '];
@@ -385,44 +415,48 @@ jobs:
 
             let prBody = `## Version Change Analysis\n\n`;
 
+            if (analysisFailed) {
+              prBody += `> ⚠️ WARNING: ANALYSIS FAILED — version and changelog could not be determined automatically. Manual review required.\n\n`;
+            }
             if (gradleBuildFailed) {
-              prBody += `> ⚠️ WARNING: GRADLE BUILD FAILED - Manual intervention required\n\n`;
+              prBody += `> ⚠️ WARNING: GRADLE BUILD FAILED — Manual intervention required\n\n`;
+            }
+            if (!pipelineSucceeded) {
+              prBody += `> ℹ️ NOTE: Gradle build was skipped — generation pipeline did not succeed, building against old files would give false results.\n\n`;
             }
 
-            prBody += `**Recommended Version Bump:** \`${analysis.changeType}\`\n`;
-            prBody += `**New Version:** \`${{ steps.update_version.outputs.new_version }}\`\n`;
-            prBody += `**Confidence:** ${analysis.confidence}\n`;
-            prBody += `**Build Status:** ${gradleBuildFailed ? '❌ FAILED' : '✅ Success'}\n`;
+            prBody += `**Recommended Version Bump:** \`${changeType}\`\n`;
+            prBody += `**New Version:** \`${newVersion}\`\n`;
+            if (analysis) prBody += `**Confidence:** ${analysis.confidence}\n`;
+            const buildStatusText = gradleBuildFailed ? '❌ FAILED' : (!pipelineSucceeded ? '⏭️ Skipped (generation pipeline failed)' : '✅ Success');
+            prBody += `**Build Status:** ${buildStatusText}\n`;
 
             if (codeOwners) {
               prBody += `**Code Owners:** ${codeOwners.split(',').map(o => `@${o}`).join(', ')}\n`;
             }
 
-            prBody += `\n### Summary\n${analysis.summary}\n\n`;
+            if (analysis) {
+              prBody += `\n### Summary\n${analysis.summary}\n\n`;
 
-            if (analysis.breakingChanges.length > 0) {
-              prBody += `### Breaking Changes\n`;
-              analysis.breakingChanges.forEach(change => {
-                prBody += `- ${formatChange(change)}\n`;
-              });
-              prBody += '\n';
+              if (analysis.breakingChanges.length > 0) {
+                prBody += `### Breaking Changes\n`;
+                analysis.breakingChanges.forEach(change => { prBody += `- ${formatChange(change)}\n`; });
+                prBody += '\n';
+              }
+              if (analysis.newFeatures.length > 0) {
+                prBody += `### New Features\n`;
+                analysis.newFeatures.forEach(feature => { prBody += `- ${formatChange(feature)}\n`; });
+                prBody += '\n';
+              }
+              if (analysis.bugFixes.length > 0) {
+                prBody += `### Improvements\n`;
+                analysis.bugFixes.forEach(fix => { prBody += `- ${formatChange(fix)}\n`; });
+                prBody += '\n';
+              }
             }
 
-            if (analysis.newFeatures.length > 0) {
-              prBody += `### New Features\n`;
-              analysis.newFeatures.forEach(feature => {
-                prBody += `- ${formatChange(feature)}\n`;
-              });
-              prBody += '\n';
-            }
-
-            if (analysis.bugFixes.length > 0) {
-              prBody += `### Improvements\n`;
-              analysis.bugFixes.forEach(fix => {
-                prBody += `- ${formatChange(fix)}\n`;
-              });
-              prBody += '\n';
-            }
+            const doNotMergePrefix = pipelineSucceeded ? '' : '[DO NOT MERGE] ';
+            const analysisPrefix = analysisFailed ? '[ANALYSIS FAILED] ' : '';
 
             const { execSync } = require('child_process');
             const hasChangelogUpdate = (() => {
@@ -455,7 +489,7 @@ jobs:
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `${buildStatus}[${analysis.changeType}] Auto-generated connector update - v${{ steps.update_version.outputs.new_version }}`,
+              title: `${doNotMergePrefix}${buildStatus}${analysisPrefix}[${changeType}] Auto-generated connector update - v${newVersion}`,
               head: branchName,
               base: 'main',
               body: prBody
@@ -469,17 +503,19 @@ jobs:
             return pr.data.number;
 
       - name: Add labels to PR
-        if: steps.diff.outputs.has_changes == 'true'
+        if: always() && steps.diff.outputs.has_changes == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
+            const analysisFailed = '${{ steps.run_analysis.outcome }}' === 'failure';
+            const pipelineSucceeded = '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true';
             const labels = ['manual-review-required'];
 
-            if (gradleBuildFailed) {
-              labels.push('build-failed');
-            }
+            if (gradleBuildFailed) labels.push('build-failed');
+            if (analysisFailed) labels.push('analysis-failed');
+            if (!pipelineSucceeded) labels.push('do-not-merge');
 
             await github.rest.issues.addLabels({
               owner: context.repo.owner,

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -65,10 +65,9 @@ jobs:
         id: diff
         run: |
           BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
-          echo "Generating diff between origin/main and origin/$BRANCH_NAME..."
-
-          git diff origin/main..origin/$BRANCH_NAME -- ballerina/client.bal > client_diff.txt || true
-          git diff origin/main..origin/$BRANCH_NAME -- ballerina/types.bal > types_diff.txt || true
+          echo "Generating diff between merge-base(origin/main, origin/$BRANCH_NAME) and origin/$BRANCH_NAME..."
+          git diff origin/main...origin/$BRANCH_NAME -- ballerina/client.bal > client_diff.txt || true
+          git diff origin/main...origin/$BRANCH_NAME -- ballerina/types.bal > types_diff.txt || true
           cat client_diff.txt types_diff.txt > git_diff.txt
 
           if [ ! -s git_diff.txt ]; then
@@ -425,11 +424,31 @@ jobs:
               prBody += '\n';
             }
 
+            const { execSync } = require('child_process');
+            const hasChangelogUpdate = (() => {
+              try {
+                const branchDiff = execSync('git diff --name-only origin/main...HEAD -- CHANGELOG.md', { encoding: 'utf8' }).trim();
+                if (branchDiff.split('\n').includes('CHANGELOG.md')) {
+                  return true;
+                }
+              } catch (error) {
+                core.warning(`Unable to determine branch diff for CHANGELOG.md: ${error.message}`);
+              }
+              try {
+                const workingTreeStatus = execSync('git status --short -- CHANGELOG.md', { encoding: 'utf8' }).trim();
+                return workingTreeStatus.length > 0;
+              } catch (error) {
+                core.warning(`Unable to determine working tree status for CHANGELOG.md: ${error.message}`);
+                return false;
+              }
+            })();
             prBody += `---\n\n`;
             if (gradleBuildFailed) {
               prBody += `⚠️ BUILD FAILED - Please fix the Gradle build errors before merging.\n`;
             }
-            prBody += `**CHANGELOG.md** has been automatically updated.\n\n`;
+            if (hasChangelogUpdate) {
+              prBody += `**CHANGELOG.md** has been automatically updated.\n\n`;
+            }
             prBody += `Manual Review Required - Please review the changes and approve if appropriate.\n`;
 
             const buildStatus = gradleBuildFailed ? '[BUILD FAILED] ' : '';

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   generate:
     name: Generate connector using reusable workflow
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'orgBBalLib' }}
-    uses: orgBBalLib/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
       - name: Clone ballerina-library scripts
         if: steps.diff.outputs.has_changes == 'true'
         run: |
-          git clone -b main https://github.com/orgBBalLib/ballerina-library.git temp-library
+          git clone -b main https://github.com/ballerina-platform/ballerina-library.git temp-library
 
       - name: Run analysis
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -105,7 +105,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           cp temp-library/connector_automator/modules/client_regenerator/analyze_version_change.bal ./
-          bal run analyze_version_change.bal -- "$(cat git_diff.txt)"
+          bal run analyze_version_change.bal -- git_diff.txt
           rm -f analyze_version_change.bal
 
       - name: Display results

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -23,7 +23,8 @@ jobs:
   analyze:
     name: Analyze connector version changes
     needs: [generate]
-    if: ${{ always() && (needs.generate.result == 'success' || needs.generate.result == 'failure') }}
+    if: ${{ always() && (needs.generate.result == 'success' || needs.generate.result == 'failure' || needs.generate.result == 'skipped') }}
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -522,7 +522,7 @@ jobs:
             return pr.data.number;
 
       - name: Add labels to PR
-        if: always() && steps.diff.outputs.has_changes == 'true'
+        if: steps.create_pr.outcome == 'success' && steps.diff.outputs.has_changes == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   generate:
     name: Generate connector using reusable workflow
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'orgBBalLib' }}
-    uses: orgBBalLib/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -96,7 +96,7 @@ jobs:
       - name: Clone ballerina-library scripts
         if: steps.diff.outputs.has_code_changes == 'true'
         run: |
-          git clone -b main https://github.com/orgBBalLib/ballerina-library.git temp-library
+          git clone -b main https://github.com/ballerina-platform/ballerina-library.git temp-library
 
       - name: Run analysis
         if: steps.diff.outputs.has_code_changes == 'true'

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   generate:
     name: Generate connector using reusable workflow
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'orgBBalLib' }}
+    uses: orgBBalLib/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -68,7 +68,6 @@ jobs:
           BRANCH_NAME="${{ steps.find_branch.outputs.branch_name }}"
           echo "Generating diff between merge-base(origin/main, origin/$BRANCH_NAME) and origin/$BRANCH_NAME..."
 
-          # Check for ANY changes in the branch (gates PR creation)
           TOTAL_CHANGED=$(git diff origin/main...origin/$BRANCH_NAME --name-only)
           if [ -z "$TOTAL_CHANGED" ]; then
             echo "No changes detected in branch"
@@ -80,7 +79,6 @@ jobs:
           echo "Changed files:"
           echo "$TOTAL_CHANGED"
 
-          # Check client.bal/types.bal specifically (gates analysis, version bump, changelog)
           git diff origin/main...origin/$BRANCH_NAME -- ballerina/client.bal > client_diff.txt || true
           git diff origin/main...origin/$BRANCH_NAME -- ballerina/types.bal > types_diff.txt || true
           cat client_diff.txt types_diff.txt > git_diff.txt
@@ -94,9 +92,8 @@ jobs:
           fi
 
       - name: Clone ballerina-library scripts
-        if: steps.diff.outputs.has_code_changes == 'true'
         run: |
-          git clone -b main https://github.com/ballerina-platform/ballerina-library.git temp-library
+          git clone -b main https://github.com/orgBBalLib/ballerina-library.git temp-library
 
       - name: Run analysis
         if: steps.diff.outputs.has_code_changes == 'true'
@@ -121,7 +118,6 @@ jobs:
           bal run "$ANALYSIS_PKG" -- git_diff.txt
           rm -rf "$ANALYSIS_PKG"
 
-
       - name: Update version in gradle.properties
         if: steps.diff.outputs.has_code_changes == 'true'
         id: update_version
@@ -135,29 +131,7 @@ jobs:
           CURRENT_VERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
           echo "Current version: $CURRENT_VERSION"
 
-          BASE_VERSION=$(echo $CURRENT_VERSION | sed 's/-SNAPSHOT//')
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
-
-          case $CHANGE_TYPE in
-            MAJOR)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            MINOR)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            PATCH)
-              PATCH=$((PATCH + 1))
-              ;;
-            *)
-              echo "Unknown change type: $CHANGE_TYPE"
-              exit 1
-              ;;
-          esac
-
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}-SNAPSHOT"
+          NEW_VERSION=$(bash temp-library/connector_automator/resources/scripts/update_version.sh "$CHANGE_TYPE" "$CURRENT_VERSION")
           echo "New version: $NEW_VERSION"
 
           sed -i "s/^version=.*/version=$NEW_VERSION/" gradle.properties
@@ -169,71 +143,9 @@ jobs:
         if: steps.diff.outputs.has_code_changes == 'true'
         continue-on-error: true
         run: |
-          echo "Building PR description for changelog..."
+          bash temp-library/connector_automator/resources/scripts/build_changelog_description.sh \
+            analysis_result.json pr_description.txt
 
-          # Initialize the PR description file
-          echo "### Summary" > pr_description.txt
-          jq -r '.summary' analysis_result.json >> pr_description.txt
-          echo "" >> pr_description.txt
-
-          # Add Breaking Changes section
-          echo "### Breaking Changes" >> pr_description.txt
-          BREAKING_COUNT=$(jq -r '.breakingChanges | length' analysis_result.json)
-          if [ "$BREAKING_COUNT" -gt 0 ]; then
-            jq -r '.breakingChanges[]' analysis_result.json | while IFS= read -r line; do
-              echo "- $line" >> pr_description.txt
-            done
-          else
-            echo "- None" >> pr_description.txt
-          fi
-          echo "" >> pr_description.txt
-
-          # Add New Features section
-          echo "### New Features" >> pr_description.txt
-          FEATURES_COUNT=$(jq -r '.newFeatures | length' analysis_result.json)
-          if [ "$FEATURES_COUNT" -gt 0 ]; then
-            jq -r '.newFeatures[]' analysis_result.json | while IFS= read -r line; do
-              echo "- $line" >> pr_description.txt
-            done
-          else
-            echo "- None" >> pr_description.txt
-          fi
-          echo "" >> pr_description.txt
-
-          # Add Improvements section
-          echo "### Improvements" >> pr_description.txt
-          FIXES_COUNT=$(jq -r '.bugFixes | length' analysis_result.json)
-          if [ "$FIXES_COUNT" -gt 0 ]; then
-            jq -r '.bugFixes[]' analysis_result.json | while IFS= read -r line; do
-              echo "- $line" >> pr_description.txt
-            done
-          else
-            echo "- None" >> pr_description.txt
-          fi
-
-          echo ""
-          echo "=== Generated PR Description ==="
-          cat pr_description.txt
-          echo "================================"
-          echo ""
-
-          # Sanitize pr_description.txt before passing to update_changelog.bal.
-          # The script does substring(0, 50) on every line it processes, which
-          # crashes on lines shorter than 50 characters. Pad every line to at
-          # least 50 characters with trailing spaces so the call is always safe.
-          python3 - <<'PYEOF'
-          with open("pr_description.txt", "r") as f:
-              lines = f.readlines()
-          with open("pr_description.txt", "w") as f:
-              for line in lines:
-                  stripped = line.rstrip("\n")
-                  if len(stripped) < 50:
-                      stripped = stripped.ljust(50)
-                  f.write(stripped + "\n")
-          PYEOF
-
-          # Run changelog updater via a temp Ballerina package
-          # (update_changelog.bal exports runUpdateChangelog, not main)
           CHANGELOG_PKG=$(mktemp -d)
           cp temp-library/connector_automator/modules/client_regenerator/update_changelog.bal "$CHANGELOG_PKG/"
           cat > "$CHANGELOG_PKG/Ballerina.toml" << 'TOML'
@@ -250,14 +162,11 @@ jobs:
           bal run "$CHANGELOG_PKG" -- "$(cat pr_description.txt)"
           rm -rf "$CHANGELOG_PKG"
 
-          # Verify CHANGELOG.md was created/updated
           if [ -f "CHANGELOG.md" ]; then
-            echo "✅ CHANGELOG.md created/updated successfully"
-            echo "First 50 lines:"
+            echo "CHANGELOG.md created/updated successfully"
             head -50 CHANGELOG.md
           else
-            echo "⚠️ WARNING: CHANGELOG.md was not created"
-            ls -la
+            echo "WARNING: CHANGELOG.md was not created"
           fi
 
       - name: Extract code owners
@@ -286,7 +195,7 @@ jobs:
         continue-on-error: true
         env:
           packageUser: ${{ github.actor }}
-          packagePAT: ${{ secrets.PAT_TOKEN }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew build -x test
           echo "Generated Ballerina files:"
@@ -300,39 +209,19 @@ jobs:
           git config --local user.email "ballerina-bot@ballerina.io"
           git config --local user.name "ballerina-bot"
 
-          echo "Files before git add:"
-          ls -la | grep -E '(CHANGELOG|gradle.properties|Ballerina.toml)'
-
-          # Add version file
           git add gradle.properties
-
           git add CHANGELOG.md 2>/dev/null || true
 
-          # Verify CHANGELOG.md is staged
-          if git diff --staged --name-only | grep -qi "changelog"; then
-            echo "✅ CHANGELOG.md is staged for commit"
-          else
-            echo "⚠️ WARNING: CHANGELOG.md is not staged!"
-            echo "Current directory contents:"
-            ls -la
-            echo "Git status:"
-            git status
-          fi
-
-          # Add generated Ballerina files if they exist
           if [ -f ballerina/Ballerina.toml ]; then
             git add ballerina/Ballerina.toml
-            echo "Added ballerina/Ballerina.toml"
           fi
           if [ -f ballerina/Dependencies.toml ]; then
             git add ballerina/Dependencies.toml
-            echo "Added ballerina/Dependencies.toml"
           fi
 
           echo "Staged files:"
           git diff --staged --name-only
 
-          # Clean up temporary files EXCEPT analysis_result.json (needed for PR creation)
           rm -f update_changelog.bal pr_description.txt git_diff.txt client_diff.txt types_diff.txt
 
           if git diff --staged --quiet; then
@@ -344,11 +233,7 @@ jobs:
             else
               COMMIT_MSG="$COMMIT_MSG and regenerate Ballerina files"
             fi
-
-            echo "Committing with message: $COMMIT_MSG"
             git commit -m "$COMMIT_MSG"
-
-            echo "Commit created. Files in commit:"
             git show --name-only --oneline HEAD
           fi
 
@@ -360,190 +245,32 @@ jobs:
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.BALLERINA_BOT_TOKEN }}
-
           script: |
-            const fs = require('fs');
-            const hasCodeChanges = '${{ steps.diff.outputs.has_code_changes }}' === 'true';
-            const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
-            const analysisFailed = '${{ steps.run_analysis.outcome }}' === 'failure';
-            const pipelineSucceeded = '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true';
-            const branchName = '${{ steps.find_branch.outputs.branch_name }}';
-            const codeOwners = '${{ steps.extract_owners.outputs.code_owners }}';
-
-            let prBody = '';
-            let prTitle = '';
-
-            if (!hasCodeChanges) {
-              // Spec-only branch — no client.bal / types.bal changes
-              prBody = `## Spec-Only Update\n\n`;
-              prBody += `This PR contains only spec/documentation updates — no changes were detected in \`client.bal\` or \`types.bal\`.\n\n`;
-              prBody += `> ℹ️ No version bump or analysis is required.\n\n`;
-              prBody += `---\n\nManual Review Required - Please review the spec changes and approve if appropriate.\n`;
-              prTitle = `[NONE] Auto-generated connector update - no version change`;
-            } else {
-              // analysis_result.json may not exist if analysis failed
-              let analysis = null;
-              try {
-                analysis = JSON.parse(fs.readFileSync('analysis_result.json', 'utf8'));
-              } catch (e) {
-                core.warning('analysis_result.json not found: ' + e.message);
+            const createPr = require('./temp-library/connector_automator/resources/scripts/create_pr.js');
+            return await createPr({
+              github, context, core, require,
+              inputs: {
+                hasCodeChanges:    '${{ steps.diff.outputs.has_code_changes }}' === 'true',
+                gradleBuildFailed: '${{ steps.gradle_build.outcome }}' === 'failure',
+                analysisFailed:    '${{ steps.run_analysis.outcome }}' === 'failure',
+                pipelineSucceeded: '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true',
+                branchName:  '${{ steps.find_branch.outputs.branch_name }}',
+                codeOwners:  '${{ steps.extract_owners.outputs.code_owners }}',
+                newVersion:  '${{ steps.update_version.outputs.new_version }}'
               }
-
-              const changeType = analysis ? analysis.changeType : 'UNKNOWN';
-              const newVersion = '${{ steps.update_version.outputs.new_version }}' || 'unknown';
-
-              function formatChange(change) {
-                const separators = [' - ', ': ', ' – '];
-                let separator = null;
-                let splitIndex = -1;
-
-                for (const sep of separators) {
-                  const idx = change.indexOf(sep);
-                  if (idx > -1) {
-                    separator = sep;
-                    splitIndex = idx;
-                    break;
-                  }
-                }
-
-                if (splitIndex > -1) {
-                  const description = change.substring(0, splitIndex);
-                  const details = change.substring(splitIndex + separator.length);
-                  const descHasCode = description.includes("'") || description.includes('"') || description.includes('`');
-
-                  if (descHasCode) {
-                    const descFormatted = description.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
-                    return `${descFormatted} - ${details}`;
-                  } else {
-                    return `${description} - \`${details}\``;
-                  }
-                }
-
-                if (change.includes("'") || change.includes('"')) {
-                  return change.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
-                }
-
-                return change;
-              }
-
-              prBody = `## Version Change Analysis\n\n`;
-
-              if (analysisFailed) {
-                prBody += `> ⚠️ WARNING: ANALYSIS FAILED — version and changelog could not be determined automatically. Manual review required.\n\n`;
-              }
-              if (gradleBuildFailed) {
-                prBody += `> ⚠️ WARNING: GRADLE BUILD FAILED — Manual intervention required\n\n`;
-              }
-              if (!pipelineSucceeded) {
-                prBody += `> ℹ️ NOTE: Gradle build was skipped — generation pipeline did not succeed, building against old files would give false results.\n\n`;
-              }
-
-              prBody += `**Recommended Version Bump:** \`${changeType}\`\n`;
-              prBody += `**New Version:** \`${newVersion}\`\n`;
-              if (analysis) prBody += `**Confidence:** ${analysis.confidence}\n`;
-              const buildStatusText = gradleBuildFailed ? '❌ FAILED' : (!pipelineSucceeded ? '⏭️ Skipped (generation pipeline failed)' : '✅ Success');
-              prBody += `**Build Status:** ${buildStatusText}\n`;
-
-              if (codeOwners) {
-                prBody += `**Code Owners:** ${codeOwners.split(',').map(o => `@${o}`).join(', ')}\n`;
-              }
-
-              if (analysis) {
-                prBody += `\n### Summary\n${analysis.summary}\n\n`;
-
-                if (analysis.breakingChanges.length > 0) {
-                  prBody += `### Breaking Changes\n`;
-                  analysis.breakingChanges.forEach(change => { prBody += `- ${formatChange(change)}\n`; });
-                  prBody += '\n';
-                }
-                if (analysis.newFeatures.length > 0) {
-                  prBody += `### New Features\n`;
-                  analysis.newFeatures.forEach(feature => { prBody += `- ${formatChange(feature)}\n`; });
-                  prBody += '\n';
-                }
-                if (analysis.bugFixes.length > 0) {
-                  prBody += `### Improvements\n`;
-                  analysis.bugFixes.forEach(fix => { prBody += `- ${formatChange(fix)}\n`; });
-                  prBody += '\n';
-                }
-              }
-
-              const doNotMergePrefix = pipelineSucceeded ? '' : '[DO NOT MERGE] ';
-              const analysisPrefix = analysisFailed ? '[ANALYSIS FAILED] ' : '';
-              const buildStatusPfx = gradleBuildFailed ? '[BUILD FAILED] ' : '';
-
-              const { execSync } = require('child_process');
-              const hasChangelogUpdate = (() => {
-                try {
-                  const branchDiff = execSync('git diff --name-only origin/main...HEAD -- CHANGELOG.md', { encoding: 'utf8' }).trim();
-                  if (branchDiff.split('\n').includes('CHANGELOG.md')) {
-                    return true;
-                  }
-                } catch (error) {
-                  core.warning(`Unable to determine branch diff for CHANGELOG.md: ${error.message}`);
-                }
-                try {
-                  const workingTreeStatus = execSync('git status --short -- CHANGELOG.md', { encoding: 'utf8' }).trim();
-                  return workingTreeStatus.length > 0;
-                } catch (error) {
-                  core.warning(`Unable to determine working tree status for CHANGELOG.md: ${error.message}`);
-                  return false;
-                }
-              })();
-              prBody += `---\n\n`;
-              if (gradleBuildFailed) {
-                prBody += `⚠️ BUILD FAILED - Please fix the Gradle build errors before merging.\n`;
-              }
-              if (hasChangelogUpdate) {
-                prBody += `**CHANGELOG.md** has been automatically updated.\n\n`;
-              }
-              prBody += `Manual Review Required - Please review the changes and approve if appropriate.\n`;
-
-              prTitle = `${doNotMergePrefix}${buildStatusPfx}${analysisPrefix}[${changeType}] Auto-generated connector update - v${newVersion}`;
-            }
-
-            const pr = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: prTitle,
-              head: branchName,
-              base: 'main',
-              body: prBody
             });
-
-            console.log(`Created PR #${pr.data.number}`);
-            core.setOutput('pr_number', pr.data.number);
-            core.setOutput('pr_url', pr.data.html_url);
-            core.setOutput('pr_title', pr.data.title);
-
-            return pr.data.number;
 
       - name: Add labels to PR
         if: steps.create_pr.outcome == 'success' && steps.diff.outputs.has_changes == 'true'
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          script: |
-            const hasCodeChanges = '${{ steps.diff.outputs.has_code_changes }}' === 'true';
-            const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
-            const analysisFailed = '${{ steps.run_analysis.outcome }}' === 'failure';
-            const pipelineSucceeded = '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true';
-            const labels = ['manual-review-required'];
-
-            if (!hasCodeChanges) {
-              labels.push('up-to-date');
-            } else {
-              if (gradleBuildFailed) labels.push('build-failed');
-              if (analysisFailed) labels.push('analysis-failed');
-            }
-            if (!pipelineSucceeded) labels.push('do-not-merge');
-
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: ${{ steps.create_pr.outputs.result }},
-              labels: labels
-            });
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          bash temp-library/connector_automator/resources/scripts/add_labels.sh \
+            "${{ steps.create_pr.outputs.result }}" \
+            "${{ steps.diff.outputs.has_code_changes }}" \
+            "${{ steps.gradle_build.outcome == 'failure' && 'true' || 'false' }}" \
+            "${{ steps.run_analysis.outcome == 'failure' && 'true' || 'false' }}" \
+            "${{ needs.generate.outputs.pipeline_succeeded }}"
 
       - name: Upload analysis results
         if: steps.diff.outputs.has_changes == 'true'

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -23,7 +23,7 @@ jobs:
   analyze:
     name: Analyze connector version changes
     needs: [generate]
-    if: ${{ always() && (needs.generate.result == 'success' || needs.generate.result == 'failure' || needs.generate.result == 'skipped') }}
+    if: ${{ !cancelled() }}
 
     runs-on: ubuntu-latest
 
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_TOKEN }}
+          token: ${{ secrets.BALLERINA_BOT_TOKEN }}
 
       - name: Install dependencies
         run: |
@@ -278,7 +278,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '21'
 
       - name: Run Gradle build to generate Ballerina files
         id: gradle_build
@@ -306,11 +306,7 @@ jobs:
           # Add version file
           git add gradle.properties
 
-          # Add CHANGELOG.md (case-insensitive, try all variants)
           git add CHANGELOG.md 2>/dev/null || true
-          git add Changelog.md 2>/dev/null || true
-          git add changelog.md 2>/dev/null || true
-          git add ChangeLog.md 2>/dev/null || true
 
           # Verify CHANGELOG.md is staged
           if git diff --staged --name-only | grep -qi "changelog"; then
@@ -363,7 +359,8 @@ jobs:
         id: create_pr
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.BALLERINA_BOT_TOKEN }}
+
           script: |
             const fs = require('fs');
             const hasCodeChanges = '${{ steps.diff.outputs.has_code_changes }}' === 'true';
@@ -525,7 +522,7 @@ jobs:
         if: steps.create_pr.outcome == 'success' && steps.diff.outputs.has_changes == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PAT_TOKEN }}
+          github-token: ${{ secrets.BALLERINA_BOT_TOKEN }}
           script: |
             const hasCodeChanges = '${{ steps.diff.outputs.has_code_changes }}' === 'true';
             const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   generate:
     name: Generate connector using reusable workflow
-    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'orgBBalLib' }}
-    uses: orgBBalLib/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'openapi-update' && github.repository_owner == 'ballerina-platform' }}
+    uses: ballerina-platform/ballerina-library/.github/workflows/auto_generate_connector_template.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
       BALLERINA_BOT_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Clone ballerina-library scripts
         run: |
-          git clone -b main https://github.com/orgBBalLib/ballerina-library.git temp-library
+          git clone -b main https://github.com/ballerina-platform/ballerina-library.git temp-library
 
       - name: Run analysis
         if: steps.diff.outputs.has_code_changes == 'true'

--- a/.github/workflows/auto-generate-connector.yml
+++ b/.github/workflows/auto-generate-connector.yml
@@ -104,19 +104,22 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          cp temp-library/connector_automator/modules/client_regenerator/analyze_version_change.bal ./
-          bal run analyze_version_change.bal -- git_diff.txt
-          rm -f analyze_version_change.bal
+          ANALYSIS_PKG=$(mktemp -d)
+          cp temp-library/connector_automator/modules/client_regenerator/analyze_version_change.bal "$ANALYSIS_PKG/"
+          cat > "$ANALYSIS_PKG/Ballerina.toml" << 'TOML'
+          [package]
+          org = "temp"
+          name = "analyze_runner"
+          version = "0.1.0"
 
-      - name: Display results
-        if: always()
-        run: |
-          if [ -f analysis_result.json ]; then
-            echo "Analysis Results:"
-            cat analysis_result.json | jq '.'
-          else
-            echo "No analysis result file found"
-          fi
+          [[dependency]]
+          org = "ballerinax"
+          name = "ai.anthropic"
+          version = "1.3.1"
+          TOML
+          bal run "$ANALYSIS_PKG" -- git_diff.txt
+          rm -rf "$ANALYSIS_PKG"
+
 
       - name: Update version in gradle.properties
         if: steps.diff.outputs.has_code_changes == 'true'
@@ -270,7 +273,7 @@ jobs:
           fi
 
       - name: Set up Java
-        if: steps.diff.outputs.has_changes == 'true' && needs.generate.outputs.pipeline_succeeded == 'true'
+        if: steps.diff.outputs.has_code_changes == 'true' && needs.generate.outputs.pipeline_succeeded == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
@@ -278,7 +281,7 @@ jobs:
 
       - name: Run Gradle build to generate Ballerina files
         id: gradle_build
-        if: steps.diff.outputs.has_changes == 'true' && needs.generate.outputs.pipeline_succeeded == 'true'
+        if: steps.diff.outputs.has_code_changes == 'true' && needs.generate.outputs.pipeline_succeeded == 'true'
         continue-on-error: true
         env:
           packageUser: ${{ github.actor }}
@@ -362,134 +365,149 @@ jobs:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             const fs = require('fs');
+            const hasCodeChanges = '${{ steps.diff.outputs.has_code_changes }}' === 'true';
             const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
             const analysisFailed = '${{ steps.run_analysis.outcome }}' === 'failure';
             const pipelineSucceeded = '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true';
             const branchName = '${{ steps.find_branch.outputs.branch_name }}';
             const codeOwners = '${{ steps.extract_owners.outputs.code_owners }}';
 
-            // analysis_result.json may not exist if analysis failed
-            let analysis = null;
-            try {
-              analysis = JSON.parse(fs.readFileSync('analysis_result.json', 'utf8'));
-            } catch (e) {
-              core.warning('analysis_result.json not found: ' + e.message);
-            }
+            let prBody = '';
+            let prTitle = '';
 
-            const changeType = analysis ? analysis.changeType : 'UNKNOWN';
-            const newVersion = '${{ steps.update_version.outputs.new_version }}' || 'unknown';
-
-            function formatChange(change) {
-              const separators = [' - ', ': ', ' – '];
-              let separator = null;
-              let splitIndex = -1;
-
-              for (const sep of separators) {
-                const idx = change.indexOf(sep);
-                if (idx > -1) {
-                  separator = sep;
-                  splitIndex = idx;
-                  break;
-                }
-              }
-
-              if (splitIndex > -1) {
-                const description = change.substring(0, splitIndex);
-                const details = change.substring(splitIndex + separator.length);
-                const descHasCode = description.includes("'") || description.includes('"') || description.includes('`');
-
-                if (descHasCode) {
-                  const descFormatted = description.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
-                  return `${descFormatted} - ${details}`;
-                } else {
-                  return `${description} - \`${details}\``;
-                }
-              }
-
-              if (change.includes("'") || change.includes('"')) {
-                return change.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
-              }
-
-              return change;
-            }
-
-            let prBody = `## Version Change Analysis\n\n`;
-
-            if (analysisFailed) {
-              prBody += `> ⚠️ WARNING: ANALYSIS FAILED — version and changelog could not be determined automatically. Manual review required.\n\n`;
-            }
-            if (gradleBuildFailed) {
-              prBody += `> ⚠️ WARNING: GRADLE BUILD FAILED — Manual intervention required\n\n`;
-            }
-            if (!pipelineSucceeded) {
-              prBody += `> ℹ️ NOTE: Gradle build was skipped — generation pipeline did not succeed, building against old files would give false results.\n\n`;
-            }
-
-            prBody += `**Recommended Version Bump:** \`${changeType}\`\n`;
-            prBody += `**New Version:** \`${newVersion}\`\n`;
-            if (analysis) prBody += `**Confidence:** ${analysis.confidence}\n`;
-            const buildStatusText = gradleBuildFailed ? '❌ FAILED' : (!pipelineSucceeded ? '⏭️ Skipped (generation pipeline failed)' : '✅ Success');
-            prBody += `**Build Status:** ${buildStatusText}\n`;
-
-            if (codeOwners) {
-              prBody += `**Code Owners:** ${codeOwners.split(',').map(o => `@${o}`).join(', ')}\n`;
-            }
-
-            if (analysis) {
-              prBody += `\n### Summary\n${analysis.summary}\n\n`;
-
-              if (analysis.breakingChanges.length > 0) {
-                prBody += `### Breaking Changes\n`;
-                analysis.breakingChanges.forEach(change => { prBody += `- ${formatChange(change)}\n`; });
-                prBody += '\n';
-              }
-              if (analysis.newFeatures.length > 0) {
-                prBody += `### New Features\n`;
-                analysis.newFeatures.forEach(feature => { prBody += `- ${formatChange(feature)}\n`; });
-                prBody += '\n';
-              }
-              if (analysis.bugFixes.length > 0) {
-                prBody += `### Improvements\n`;
-                analysis.bugFixes.forEach(fix => { prBody += `- ${formatChange(fix)}\n`; });
-                prBody += '\n';
-              }
-            }
-
-            const doNotMergePrefix = pipelineSucceeded ? '' : '[DO NOT MERGE] ';
-            const analysisPrefix = analysisFailed ? '[ANALYSIS FAILED] ' : '';
-
-            const { execSync } = require('child_process');
-            const hasChangelogUpdate = (() => {
+            if (!hasCodeChanges) {
+              // Spec-only branch — no client.bal / types.bal changes
+              prBody = `## Spec-Only Update\n\n`;
+              prBody += `This PR contains only spec/documentation updates — no changes were detected in \`client.bal\` or \`types.bal\`.\n\n`;
+              prBody += `> ℹ️ No version bump or analysis is required.\n\n`;
+              prBody += `---\n\nManual Review Required - Please review the spec changes and approve if appropriate.\n`;
+              prTitle = `[NONE] Auto-generated connector update - no version change`;
+            } else {
+              // analysis_result.json may not exist if analysis failed
+              let analysis = null;
               try {
-                const branchDiff = execSync('git diff --name-only origin/main...HEAD -- CHANGELOG.md', { encoding: 'utf8' }).trim();
-                if (branchDiff.split('\n').includes('CHANGELOG.md')) {
-                  return true;
-                }
-              } catch (error) {
-                core.warning(`Unable to determine branch diff for CHANGELOG.md: ${error.message}`);
+                analysis = JSON.parse(fs.readFileSync('analysis_result.json', 'utf8'));
+              } catch (e) {
+                core.warning('analysis_result.json not found: ' + e.message);
               }
-              try {
-                const workingTreeStatus = execSync('git status --short -- CHANGELOG.md', { encoding: 'utf8' }).trim();
-                return workingTreeStatus.length > 0;
-              } catch (error) {
-                core.warning(`Unable to determine working tree status for CHANGELOG.md: ${error.message}`);
-                return false;
-              }
-            })();
-            prBody += `---\n\n`;
-            if (gradleBuildFailed) {
-              prBody += `⚠️ BUILD FAILED - Please fix the Gradle build errors before merging.\n`;
-            }
-            if (hasChangelogUpdate) {
-              prBody += `**CHANGELOG.md** has been automatically updated.\n\n`;
-            }
-            prBody += `Manual Review Required - Please review the changes and approve if appropriate.\n`;
 
-            const buildStatus = gradleBuildFailed ? '[BUILD FAILED] ' : '';
+              const changeType = analysis ? analysis.changeType : 'UNKNOWN';
+              const newVersion = '${{ steps.update_version.outputs.new_version }}' || 'unknown';
+
+              function formatChange(change) {
+                const separators = [' - ', ': ', ' – '];
+                let separator = null;
+                let splitIndex = -1;
+
+                for (const sep of separators) {
+                  const idx = change.indexOf(sep);
+                  if (idx > -1) {
+                    separator = sep;
+                    splitIndex = idx;
+                    break;
+                  }
+                }
+
+                if (splitIndex > -1) {
+                  const description = change.substring(0, splitIndex);
+                  const details = change.substring(splitIndex + separator.length);
+                  const descHasCode = description.includes("'") || description.includes('"') || description.includes('`');
+
+                  if (descHasCode) {
+                    const descFormatted = description.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
+                    return `${descFormatted} - ${details}`;
+                  } else {
+                    return `${description} - \`${details}\``;
+                  }
+                }
+
+                if (change.includes("'") || change.includes('"')) {
+                  return change.replace(/'([^']+)'/g, '`$1`').replace(/"([^"]+)"/g, '`$1`');
+                }
+
+                return change;
+              }
+
+              prBody = `## Version Change Analysis\n\n`;
+
+              if (analysisFailed) {
+                prBody += `> ⚠️ WARNING: ANALYSIS FAILED — version and changelog could not be determined automatically. Manual review required.\n\n`;
+              }
+              if (gradleBuildFailed) {
+                prBody += `> ⚠️ WARNING: GRADLE BUILD FAILED — Manual intervention required\n\n`;
+              }
+              if (!pipelineSucceeded) {
+                prBody += `> ℹ️ NOTE: Gradle build was skipped — generation pipeline did not succeed, building against old files would give false results.\n\n`;
+              }
+
+              prBody += `**Recommended Version Bump:** \`${changeType}\`\n`;
+              prBody += `**New Version:** \`${newVersion}\`\n`;
+              if (analysis) prBody += `**Confidence:** ${analysis.confidence}\n`;
+              const buildStatusText = gradleBuildFailed ? '❌ FAILED' : (!pipelineSucceeded ? '⏭️ Skipped (generation pipeline failed)' : '✅ Success');
+              prBody += `**Build Status:** ${buildStatusText}\n`;
+
+              if (codeOwners) {
+                prBody += `**Code Owners:** ${codeOwners.split(',').map(o => `@${o}`).join(', ')}\n`;
+              }
+
+              if (analysis) {
+                prBody += `\n### Summary\n${analysis.summary}\n\n`;
+
+                if (analysis.breakingChanges.length > 0) {
+                  prBody += `### Breaking Changes\n`;
+                  analysis.breakingChanges.forEach(change => { prBody += `- ${formatChange(change)}\n`; });
+                  prBody += '\n';
+                }
+                if (analysis.newFeatures.length > 0) {
+                  prBody += `### New Features\n`;
+                  analysis.newFeatures.forEach(feature => { prBody += `- ${formatChange(feature)}\n`; });
+                  prBody += '\n';
+                }
+                if (analysis.bugFixes.length > 0) {
+                  prBody += `### Improvements\n`;
+                  analysis.bugFixes.forEach(fix => { prBody += `- ${formatChange(fix)}\n`; });
+                  prBody += '\n';
+                }
+              }
+
+              const doNotMergePrefix = pipelineSucceeded ? '' : '[DO NOT MERGE] ';
+              const analysisPrefix = analysisFailed ? '[ANALYSIS FAILED] ' : '';
+              const buildStatusPfx = gradleBuildFailed ? '[BUILD FAILED] ' : '';
+
+              const { execSync } = require('child_process');
+              const hasChangelogUpdate = (() => {
+                try {
+                  const branchDiff = execSync('git diff --name-only origin/main...HEAD -- CHANGELOG.md', { encoding: 'utf8' }).trim();
+                  if (branchDiff.split('\n').includes('CHANGELOG.md')) {
+                    return true;
+                  }
+                } catch (error) {
+                  core.warning(`Unable to determine branch diff for CHANGELOG.md: ${error.message}`);
+                }
+                try {
+                  const workingTreeStatus = execSync('git status --short -- CHANGELOG.md', { encoding: 'utf8' }).trim();
+                  return workingTreeStatus.length > 0;
+                } catch (error) {
+                  core.warning(`Unable to determine working tree status for CHANGELOG.md: ${error.message}`);
+                  return false;
+                }
+              })();
+              prBody += `---\n\n`;
+              if (gradleBuildFailed) {
+                prBody += `⚠️ BUILD FAILED - Please fix the Gradle build errors before merging.\n`;
+              }
+              if (hasChangelogUpdate) {
+                prBody += `**CHANGELOG.md** has been automatically updated.\n\n`;
+              }
+              prBody += `Manual Review Required - Please review the changes and approve if appropriate.\n`;
+
+              prTitle = `${doNotMergePrefix}${buildStatusPfx}${analysisPrefix}[${changeType}] Auto-generated connector update - v${newVersion}`;
+            }
+
             const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `${doNotMergePrefix}${buildStatus}${analysisPrefix}[${changeType}] Auto-generated connector update - v${newVersion}`,
+              title: prTitle,
               head: branchName,
               base: 'main',
               body: prBody
@@ -508,13 +526,18 @@ jobs:
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
+            const hasCodeChanges = '${{ steps.diff.outputs.has_code_changes }}' === 'true';
             const gradleBuildFailed = '${{ steps.gradle_build.outcome }}' === 'failure';
             const analysisFailed = '${{ steps.run_analysis.outcome }}' === 'failure';
             const pipelineSucceeded = '${{ needs.generate.outputs.pipeline_succeeded }}' === 'true';
             const labels = ['manual-review-required'];
 
-            if (gradleBuildFailed) labels.push('build-failed');
-            if (analysisFailed) labels.push('analysis-failed');
+            if (!hasCodeChanges) {
+              labels.push('up-to-date');
+            } else {
+              if (gradleBuildFailed) labels.push('build-failed');
+              if (analysisFailed) labels.push('analysis-failed');
+            }
             if (!pipelineSucceeded) labels.push('do-not-merge');
 
             await github.rest.issues.addLabels({


### PR DESCRIPTION
A workflow which will regenerate the connector when there is an update in openapi spec and do the version analysis

## Purpose
Issue - https://github.com/ballerina-platform/ballerina-library/issues/8510


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a GitHub Actions workflow to automate connector regeneration, impact analysis, and version management when OpenAPI specs change or on manual invocation. The workflow can be triggered manually or via repository_dispatch events and calls a reusable connector-generation workflow. It detects whether the auto-generated branch contains changes and specifically checks ballerina/client.bal and ballerina/types.bal to decide if semantic version analysis and changelog updates are required.

When client/types code changes are detected, the workflow runs a version analysis script from the ballerina-library repository, computes a semantic version bump (appending -SNAPSHOT) in gradle.properties based on the analysis result, and constructs a structured changelog entry which it applies to CHANGELOG.md. It also attempts a Gradle build to regenerate Ballerina artifacts, commits and pushes updated version, changelog, and regenerated files to the auto-generated branch, and creates a pull request with the recommended version bump, analysis summary, build/analysis warnings, and relevant labels. For spec-only changes (no client/types changes) the workflow creates a spec-only PR and skips version analysis. The workflow uploads analysis/diff artifacts, extracts code owners for PR context, and performs cleanup of temporary files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->