### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.associations.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.associations/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.associations.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.associations)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.associations.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.associations)
 
 ## Overview
 


### PR DESCRIPTION
## Purpose

Fixes a documentation issue identified in the HubSpot connector audit. The GitHub Issues badge link in the top-level `README.md` had a half-encoded URL (`module%hubspot.crm.associations`), which prevented the badge link from resolving. Replaced with the correctly encoded `module%2Fhubspot.crm.associations` segment.

Refs ballerina-platform/ballerina-library#8823

## Examples

N/A - documentation-only change.

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog — N/A, documentation-only fix
- [ ] Added tests — N/A, documentation-only fix
- [ ] Updated the spec — N/A, documentation-only fix
- [ ] Checked native-image compatibility — N/A, documentation-only fix